### PR TITLE
use generator instead of list comprehension in sum

### DIFF
--- a/signal_rate_block.py
+++ b/signal_rate_block.py
@@ -78,7 +78,7 @@ class SignalRate(GroupBy, Persistence, Block):
             signals = copy(self._signal_counts[group])
 
         # Add up all of our current counts
-        total_count = sum([grp[1] for grp in signals])
+        total_count = sum(grp[1] for grp in signals)
 
         # If we haven't reached a full period, divide by elapsed time
         rate = total_count / min(


### PR DESCRIPTION
When looping over something only once as in sum(), using a generator expression can save memory and overhead when dealing with large numbers of signals or summing many times. 
